### PR TITLE
client build error (ERR_OSSL_EVP_UNSUPPORTED) when node version >= 17

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -60,7 +60,7 @@
   "scripts": {
     "start": "react-app-rewired start -FAST_REFRESH=true",
     "start:plugin": "REACT_APP_PLUGIN_DEV=true react-app-rewired start -FAST_REFRESH=true",
-    "build": "react-app-rewired build",
+    "build": "react-app-rewired --openssl-legacy-provider build",
     "test": "react-app-rewired test",
     "test:watch": "react-app-rewired test --watch",
     "test:cov": "react-app-rewired test --watchAll=false --coverage",


### PR DESCRIPTION
Add `--openssl-legacy-provider` to scripts.

Signed-off-by: min.tian <min.tian.cn@gmail.com>