### PR TITLE
better search page

### DIFF
--- a/client/src/i18n/cn/button.ts
+++ b/client/src/i18n/cn/button.ts
@@ -21,7 +21,8 @@ const btnTrans = {
   query: 'Query',
   importSampleData: 'Import Sample data',
   loading: 'Loading...',
-  importing: 'Importing...'
+  importing: 'Importing...',
+  example: 'Example',
 };
 
 export default btnTrans;

--- a/client/src/i18n/cn/search.ts
+++ b/client/src/i18n/cn/search.ts
@@ -1,5 +1,5 @@
 const searchTrans = {
-  firstTip: '1. Enter vector value {{dimensionTip}}',
+  firstTip: '1. Enter search vector {{dimensionTip}}',
   secondTip: '2. Choose collection and field',
   thirdTip: '3. Set search parameters',
   vectorPlaceholder: 'Please input your vector value here, e.g. [1, 2, 3, 4]',

--- a/client/src/i18n/en/button.ts
+++ b/client/src/i18n/en/button.ts
@@ -21,7 +21,8 @@ const btnTrans = {
   query: 'Query',
   importSampleData: 'Import Sample data',
   loading: 'Loading...',
-  importing: 'Importing...'
+  importing: 'Importing...',
+  example: 'Example',
 };
 
 export default btnTrans;

--- a/client/src/i18n/en/search.ts
+++ b/client/src/i18n/en/search.ts
@@ -1,6 +1,6 @@
 const searchTrans = {
-  firstTip: '1. Enter vector value {{dimensionTip}}',
-  secondTip: '2. Choose collection and field',
+  firstTip: '2. Enter search vector {{dimensionTip}}',
+  secondTip: '1. Choose collection and field',
   thirdTip: '3. Set search parameters',
   vectorPlaceholder: 'Please input your vector value here, e.g. [1, 2, 3, 4]',
   collection: 'Choose Collection',

--- a/client/src/pages/search/SearchParams.tsx
+++ b/client/src/pages/search/SearchParams.tsx
@@ -20,13 +20,12 @@ import { SearchParamInputConfig, SearchParamsProps } from './Types';
 const getStyles = makeStyles((theme: Theme) => ({
   selector: {
     width: '100%',
-    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
   },
   input: {
-    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
   },
   inlineInput: {
-    marginTop: theme.spacing(2),
     width: '48%',
   },
   inlineInputWrapper: {

--- a/client/src/pages/search/Styles.ts
+++ b/client/src/pages/search/Styles.ts
@@ -8,9 +8,8 @@ export const getVectorSearchStyles = makeStyles((theme: Theme) => ({
     '& .field': {
       display: 'flex',
       flexDirection: 'column',
-      flexBasis: '33%',
-
-      padding: theme.spacing(2, 3, 4),
+      width: 250,
+      padding: theme.spacing(2),
       backgroundColor: '#fff',
       borderRadius: theme.spacing(0.5),
       boxShadow: '3px 3px 10px rgba(0, 0, 0, 0.05)',
@@ -18,17 +17,16 @@ export const getVectorSearchStyles = makeStyles((theme: Theme) => ({
       '& .textarea': {
         border: `1px solid ${theme.palette.attuGrey.main}`,
         borderRadius: theme.spacing(0.5),
-        padding: theme.spacing(1),
-        paddingBottom: '18px',
-        marginTop: theme.spacing(2),
+        padding: theme.spacing(0, 1),
+        marginBottom: theme.spacing(0.5),
       },
 
       // reset default style
       '& .textfield': {
-        padding: 0,
         fontSize: '14px',
         lineHeight: '20px',
         fontWeight: 400,
+        height: '128px',
 
         '&::before': {
           borderBottom: 'none',
@@ -61,6 +59,7 @@ export const getVectorSearchStyles = makeStyles((theme: Theme) => ({
 
     '& .field-second': {
       flexGrow: 1,
+      flexBasis: '50%',
       margin: theme.spacing(0, 1),
     },
 
@@ -68,16 +67,25 @@ export const getVectorSearchStyles = makeStyles((theme: Theme) => ({
     // if still set padding-bottom, the whole form space will be stretched
     '& .field-params': {
       paddingBottom: 0,
+      width: 390,
     },
 
     '& .text': {
       color: theme.palette.attuGrey.dark,
       fontWeight: 500,
+      marginBottom: theme.spacing(1),
+      height: theme.spacing(4),
+      '& button': {
+        marginLeft: '8px',
+        position: 'relative',
+        top: -5,
+        verticalAlign: 'top',
+      },
     },
   },
   selector: {
     width: '100%',
-    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
   },
   paramsWrapper: {
     display: 'flex',
@@ -123,7 +131,6 @@ export const getVectorSearchStyles = makeStyles((theme: Theme) => ({
     color: theme.palette.attuGrey.dark,
   },
   error: {
-    marginTop: theme.spacing(1),
     color: theme.palette.error.main,
   },
 }));


### PR DESCRIPTION
- adjust search page layout
- user choose different collection, the metric box should fill with metric value of the collection automatically
- user now can fill example vector into the search box

![image](https://user-images.githubusercontent.com/185051/207553818-287633cc-1973-472d-a541-8ac9e080a501.png)
