### PR TITLE
fix: http cannot be copied

### DIFF
--- a/client/src/components/advancedSearch/CopyButton.tsx
+++ b/client/src/components/advancedSearch/CopyButton.tsx
@@ -13,12 +13,29 @@ const CopyButton: FC<CopyButtonProps> = props => {
   const { t: commonTrans } = useTranslation();
   const copyTrans = commonTrans('copy');
   const [tooltipTitle, setTooltipTitle] = useState('Copy');
-
+  
+  const unsecuredCopyToClipboard = (v: string) => {
+    const textArea = document.createElement("textarea");
+    textArea.style.position = 'fixed';
+    textArea.style.opacity = '0';
+    textArea.style.zIndex = '-1000';
+    textArea.value = v;
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    try {
+      document.execCommand('copy');
+    } catch (err) {
+      console.error('Unable to copy to clipboard', err);
+    }
+    document.body.removeChild(textArea);
+  }
+  
   const handleClick = (event: React.MouseEvent<HTMLElement>, v: string) => {
     event.stopPropagation();
 
     setTooltipTitle(copyTrans.copied);
-    navigator.clipboard.writeText(v);
+    (navigator.clipboard?.writeText ?? unsecuredCopyToClipboard)?.(v);
     setTimeout(() => {
       setTooltipTitle(copyTrans.copy);
     }, 1000);


### PR DESCRIPTION
The use of navigator.clipboard requires a secure origin. So if your dev environment is being served over HTTP, then the clipboard method won't be available.