### PR TITLE
TLS Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,62 @@ Make sure that the Attu container can access the Milvus IP address. After starti
 
 Note that "127.0.0.1" or "localhost" will not work when running Attu on Docker.
 
+## TLS Configuration Guide
+
+The Attu Docker container can be configured to be compatible with one-way and two-way TLS. 
+
+### Enabling TLS 
+
+You can enable TLS by running the Docker container with the `ENABLE_TLS` environment variable set to `true`:
+
+```
+docker run -e ENABLE_TLS=true zilliz/attu:v2.2.3
+```
+
+### Certificate and Key Mapping
+
+For the TLS configuration to function correctly, you must map your desired certificates and keys to the Docker container using volume bindings:
+
+```
+docker run -e ENABLE_TLS=true
+-p 8000:3000
+-v /path/to/ca.pem:/app/ca.pem
+-v /path/to/client.pem:/app/client.pem
+-v /path/to/client.key:/app/client.key
+zilliz/attu:v2.2.3
+```
+
+### Arguments
+
+You can provide the following arguments when running the Docker container:
+
+1. **Certificate Authority / Server Certificates (CA pem or Server Pem)**: This argument defaults to `ca.pem`. The presence of this file is required. You can provide this file by binding it to `/app/ca.pem` in the Docker container.
+   
+2. **Client Certificates (Client Pem, and Client Key)**: These arguments default to `null`. The presence of both of these files is optional for one-way TLS (tlsMode 1) and required for two-way TLS (tlsMode 2). You can provide these files by binding them to `/app/client.pem` and `/app/client.key` in the Docker container.
+   
+3. **Common Name**: This argument defaults to `localhost`. You can override this by setting the `COMMON_NAME` environment variable when running the Docker container:
+
+TLSMode 2
+```
+docker run -e ENABLE_TLS=true
+-e COMMON_NAME=your_common_name
+-p 8000:3000
+-v /path/to/ca.pem:/app/ca.pem
+-v /path/to/client.pem:/app/client.pem
+-v /path/to/client.key:/app/client.key
+zilliz/attu:v2.2.3
+```
+
+TLSMode 1
+```
+docker run -e ENABLE_TLS=true \
+  -e COMMON_NAME=your_common_name
+  -v /path/to/ca.pem:/app/ca.pem \
+  zilliz/attu:v2.2.3
+```
+
+Please replace `your_common_name`, `/path/to/ca.pem`, `/path/to/client.pem`, and `/path/to/client.key` with the actual values according to your setup.
+
 ## Screenshots
 
 <img src="./.github/images/screenshot.png" alt="attu" width="800" alt="attu" />

--- a/tls-patch.sh
+++ b/tls-patch.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+
+escape_string() {
+    echo "$1" | sed -e 's/[\/&]/\\&/g'
+}
+
+# Function to add a line before a specific line in a file
+add_string() {
+    filename="$1"
+    search_string=$(escape_string "$2")
+    line_to_add="$3"
+
+    # Check if the string already exists in the file
+    if ! grep -q "$line_to_add" "$filename"; then
+
+        # Check if the OS is macOS or Linux and use the appropriate sed syntax
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "/$search_string/i\\
+            $line_to_add\\
+            " "$filename"
+        else
+            sed -i "/$search_string/i $line_to_add\\n" "$filename"
+        fi
+    fi
+}
+
+# Function to replace a string in a file
+replace_string() {
+    filename="$1"
+    search_string=$(escape_string "$2")
+    replacement_string="$3"
+
+    # Check if the OS is macOS or Linux and use the appropriate sed syntax
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s/$search_string/$replacement_string/g" "$filename"
+    else
+        sed -i "s/$search_string/$replacement_string/g" "$filename"
+    fi
+}
+# Define the variables (similar to the arguments in the original main function)
+# Default values for the variables
+ca_file_path="ca.pem"
+key_file_path=null
+pem_file_path=null
+common_name="localhost"
+
+for i in "$@"
+do
+case $i in
+    -ca=*|--cafile=*)
+    ca_file_path="${i#*=}"
+    shift
+    ;;
+    -key=*|--keyfile=*)
+    key_file_path="${i#*=}"
+    shift
+    ;;
+    -cert=*|--certfile=*)
+    pem_file_path="${i#*=}"
+    shift
+    ;;
+    -cn=*|--commonname=*)
+    common_name="${i#*=}"
+    shift
+    ;;
+esac
+done
+
+
+# Assume that the mod_file is known and is a parameter to the script
+mod_file=$(find ./node_modules/@zilliz/milvus2-sdk-node/dist/milvus -name "GrpcClient.js")
+
+# Add the necessary lines to the file
+add_string "$mod_file" "this.client = new MilvusService" "var ca = fs_1.readFileSync(\"$ca_file_path\");"
+if [[ -n "$key_file_path" && "$key_file_path" != "null" ]]; then
+  add_string "$mod_file" "this.client = new MilvusService" "var key = fs_1.readFileSync(\"$key_file_path\");"
+else
+  add_string "$mod_file" "this.client = new MilvusService" "var key = null;"
+fi
+if [[ -n "$pem_file_path" && "$pem_file_path" != "null" ]]; then
+  add_string "$mod_file" "this.client = new MilvusService" "var cert = fs_1.readFileSync(\"$pem_file_path\");"
+else
+  add_string "$mod_file" "this.client = new MilvusService" "var cert = null;"
+fi
+add_string "$mod_file" "this.config.channelOptions" "\"grpc.ssl_target_name_override\": \"$common_name\","
+add_string "$mod_file" "require(\"./User\")" "var fs_1 = require(\"fs\");"
+
+# Replace a specific string in the file
+replace_string "$mod_file" "credentials.createSsl()" "credentials.createSsl(ca, key, cert, true)"


### PR DESCRIPTION
Until TLS support is added directly to the milvus_sdk_node package, users can use this patch in order to get SSL working with their Milvus instance. 
I've updated the ReadMe as well to demonstrate usage guide. 