### PR TITLE
add arm64 support & bump actions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -12,11 +12,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       # - name: Run server tests
       #   run: |
@@ -33,13 +40,18 @@ jobs:
       #     flags: server
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PWD }}
 
-      - name: Docker Build
-        run: docker build -t zilliz/attu:dev --build-arg VERSION=dev .
-
-      - name: Docker Push Dev
-        run: docker push zilliz/attu:dev
+      - name: Docker Build&Push
+        shell: bash
+        run: |
+          docker buildx build \
+            --platform=linux/amd64,linux/arm64 \
+            -t zilliz/attu:dev \
+            --build-arg VERSION=dev \
+            --push \
+            --progress=plain \
+            .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,26 +8,33 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PWD }}
 
-      - name: Docker Build
-        run: docker build -t zilliz/attu:${GITHUB_REF#refs/tags/} --build-arg VERSION=${GITHUB_REF#refs/tags/} .
-
-      - name: Docker tag
-        run: docker tag zilliz/attu:${GITHUB_REF#refs/tags/} zilliz/attu:latest
-
-      - name: Docker Push version
-        run: docker push zilliz/attu:${GITHUB_REF#refs/tags/}
-
-      - name: Docker Push lastest
-        run: docker push zilliz/attu
+      - name: Docker Build&Push
+        shell: bash
+        run: |
+          docker buildx build \
+            --platform=linux/amd64,linux/arm64 \
+            -t zilliz/attu:${GITHUB_REF#refs/tags/} \
+            -t zilliz/attu:latest \
+            --build-arg VERSION=${GITHUB_REF#refs/tags/} \
+            --push \
+            --progress=plain \
+            .


### PR DESCRIPTION
[As Milvus support arm64 images](https://milvus.io/docs/release_notes.md#Arm64-Support), this PR attempts to add the same capability for attu.

Some caveats
- [QEMU + Yarn can be extremely slow](https://github.com/nodejs/docker-node/issues/1335)
- GH Actions runner does not support native arm machines
