### PR TITLE
using query for count

### DIFF
--- a/client/src/http/Axios.ts
+++ b/client/src/http/Axios.ts
@@ -12,7 +12,7 @@ export const url =
 
 const axiosInstance = axios.create({
   baseURL: `${url}/api/v1`,
-  timeout: 60000,
+  timeout: 60000 * 5, // 5 minutes
 });
 
 axiosInstance.interceptors.request.use(

--- a/client/src/http/Collection.ts
+++ b/client/src/http/Collection.ts
@@ -173,7 +173,7 @@ export class CollectionHttp extends BaseModel implements CollectionView {
   }
 
   get _aliases() {
-    return this.aliases;
+    return this.aliases || [];
   }
 
   get _desc() {
@@ -234,11 +234,11 @@ export class CollectionHttp extends BaseModel implements CollectionView {
   }
 
   get _replicas(): Replica[] {
-    return this.replicas;
+    return this.replicas || [];
   }
 
   get _enableDynamicField(): boolean {
-    return this.schema.enable_dynamic_field;
+    return this.schema && this.schema.enable_dynamic_field;
   }
 
   get _schema() {

--- a/client/src/i18n/en/collection.ts
+++ b/client/src/i18n/en/collection.ts
@@ -3,6 +3,7 @@ const collectionTrans = {
   noData: 'No Collection',
 
   rowCount: 'Approx Count',
+  count: 'Entity Count',
 
   create: 'Collection',
   delete: 'delete',

--- a/client/src/i18n/en/dialog.ts
+++ b/client/src/i18n/en/dialog.ts
@@ -9,7 +9,7 @@ const dialogTrans = {
   loadTitle: `Load {{type}}`,
 
   loadContent: `You are trying to load a {{type}} with data. Only loaded {{type}} can be searched.`,
-  releaseContent: `You are trying to release a {{type}} with data. Please be aware that the data will no longer be available for search.`,
+  releaseContent: `You are trying to release {{type}} with data. Please be aware that the data will no longer be available for search.`,
 
   createTitle: `Create {{type}} on "{{name}}"`,
 };

--- a/client/src/i18n/en/overview.ts
+++ b/client/src/i18n/en/overview.ts
@@ -1,7 +1,7 @@
 const overviewTrans = {
   load: 'Loaded Collections',
   all: 'All Collections',
-  data: 'Entities',
+  data: 'Approx Entities',
   rows: '{{number}}',
   loading: 'Loading Collections',
   sysInfo: 'System Info',

--- a/client/src/pages/overview/Overview.tsx
+++ b/client/src/pages/overview/Overview.tsx
@@ -17,6 +17,7 @@ import { LOADING_STATE, MILVUS_DEPLOY_MODE } from '@/consts';
 import { WS_EVENTS, WS_EVENTS_TYPE } from '@server/utils/Const';
 import { useNavigationHook } from '@/hooks';
 import { CollectionHttp, MilvusHttp } from '@/http';
+import { ShowCollectionsType } from '@/types/Milvus';
 import { ALL_ROUTER_TYPES } from '@/router/Types';
 import { checkLoading, checkIndexBuilding, formatNumber } from '@/utils';
 import CollectionCard from './collectionCard/CollectionCard';
@@ -106,6 +107,11 @@ const SysCard = (data: {
   );
 };
 
+type statisticsType = {
+  collectionCount: number;
+  totalData: number;
+};
+
 const Overview = () => {
   useNavigationHook(ALL_ROUTER_TYPES.OVERVIEW);
   const { database, databases, data } = useContext(dataContext);
@@ -114,10 +120,7 @@ const Overview = () => {
   const { t: overviewTrans } = useTranslation('overview');
   const { t: collectionTrans } = useTranslation('collection');
   const { t: successTrans } = useTranslation('success');
-  const [statistics, setStatistics] = useState<{
-    collectionCount: number;
-    totalData: number;
-  }>({
+  const [statistics, setStatistics] = useState<statisticsType>({
     collectionCount: 0,
     totalData: 0,
   });
@@ -127,8 +130,10 @@ const Overview = () => {
 
   const fetchData = useCallback(async () => {
     setLoading(true);
-    const res = await CollectionHttp.getStatistics();
-    const collections = await CollectionHttp.getCollections();
+    const res = (await CollectionHttp.getStatistics()) as statisticsType;
+    const collections = await CollectionHttp.getCollections({
+      type: ShowCollectionsType.InMemory,
+    });
     const hasLoadingOrBuildingCollection = collections.some(
       v => checkLoading(v) || checkIndexBuilding(v)
     );

--- a/client/src/pages/overview/collectionCard/CollectionCard.tsx
+++ b/client/src/pages/overview/collectionCard/CollectionCard.tsx
@@ -146,7 +146,7 @@ const CollectionCard: FC<CollectionCardProps> = ({
             </li>
           ) : null}
           <li>
-            <Typography>{collectionTrans('rowCount')}</Typography>:
+            <Typography>{collectionTrans('count')}</Typography>:
             <Typography className={classes.rowCount}>{rowCount}</Typography>
           </li>
         </ul>

--- a/server/src/collections/collections.service.ts
+++ b/server/src/collections/collections.service.ts
@@ -234,15 +234,15 @@ export class CollectionsService {
         let count: number | string;
 
         try {
-          const res = await this.count({
+          const countRes = await this.count({
             collection_name: name,
           });
-          count = res.data;
+          count = countRes.data;
         } catch (error) {
-          const res = await this.getCollectionStatistics({
+          const collectionStatisticsRes = await this.getCollectionStatistics({
             collection_name: name,
           });
-          count = res.data.row_count;
+          count = collectionStatisticsRes.data.row_count;
         }
 
         data.push({


### PR DESCRIPTION
After milvus 2.3, we can use query to get precise data count, in this pr, I modified showLoadedCollection api, so it will return precise data count if supported.

![image](https://github.com/zilliztech/attu/assets/185051/840f3d9a-b2d3-41e6-ba09-7390af88e70e)


This fix #304 
