### PR TITLE
Adding Kubernetes Deployment Documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ docker run -p 8000:3000 -e MILVUS_URL={milvus server IP}:19530 zilliz/attu:v2.3.
 
 Make sure that the Attu container can access the Milvus IP address. After starting the container, open your web browser and enter `http://{ Attu IP }:8000` to view the Attu GUI.
 
+### Running Attu within Kubernetes
+
+Before you begin, make sure that you have Milvus installed and running within your [K8's Cluster](https://milvus.io/docs/install_cluster-milvusoperator.md). Note that Attu only supports Milvus 2.x.
+
+Here are the steps to start a container for running Attu:
+
+```code
+kubectl apply -f https://raw.githubusercontent.com/zilliztech/attu/main/attu-k8s-deploy.yaml
+```
+
+Make sure that the Attu pod can access the Milvus service. After starting the container. In the example provided this connects directly to `my-release-milvus:19530`. Change this based on the Milvus service name. A more flexible way to achieve this would be to introduce a `ConfigMap`. See this [example]("https://raw.githubusercontent.com/zilliztech/attu/main/examples/attu-k8s-deploy-ConfigMap.yaml") for details.
+
 #### Parameters for Docker CLI
 
 | Parameter  | Example           | Required | Description                 |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Here are the steps to start a container for running Attu:
 kubectl apply -f https://raw.githubusercontent.com/zilliztech/attu/main/attu-k8s-deploy.yaml
 ```
 
-Make sure that the Attu pod can access the Milvus service. After starting the container. In the example provided this connects directly to `my-release-milvus:19530`. Change this based on the Milvus service name. A more flexible way to achieve this would be to introduce a `ConfigMap`. See this [example]("https://raw.githubusercontent.com/zilliztech/attu/main/examples/attu-k8s-deploy-ConfigMap.yaml") for details.
+Make sure that the Attu pod can access the Milvus service. In the example provided this connects directly to `my-release-milvus:19530`. Change this based on the Milvus service name. A more flexible way to achieve this would be to introduce a `ConfigMap`. See this [example]("https://raw.githubusercontent.com/zilliztech/attu/main/examples/attu-k8s-deploy-ConfigMap.yaml") for details.
 
 #### Parameters for Docker CLI
 

--- a/attu-k8s-deploy.yaml
+++ b/attu-k8s-deploy.yaml
@@ -40,4 +40,4 @@ spec:
           protocol: TCP
         env:
         - name: MILVUS_URL
-          value: 127.0.0.1:19530
+          value: "my-release-milvus:19530"

--- a/examples/attu-k8s-deploy-ConfigMap.yaml
+++ b/examples/attu-k8s-deploy-ConfigMap.yaml
@@ -14,6 +14,13 @@ spec:
   selector:
     app: attu
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: milvus-config
+data:
+  milvus_url: "<SERVICE>:<PORT>"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,4 +47,7 @@ spec:
           protocol: TCP
         env:
         - name: MILVUS_URL
-          value: "my-release-milvus:19530"
+          valueFrom:
+            configMapKeyRef:
+              name: milvus-config
+              key: milvus_url

--- a/examples/attu-k8s-deploy.yaml
+++ b/examples/attu-k8s-deploy.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-attu-svc
+  labels:
+    app: attu
+spec:
+  type: ClusterIP
+  ports:
+  - name: attu
+    protocol: TCP
+    port: 3000
+    targetPort: 3000
+  selector:
+    app: attu
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-attu
+  labels:
+    app: attu
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: attu
+  template:
+    metadata:
+      labels:
+        app: attu
+    spec:
+      containers:
+      - name: attu
+        image: zilliz/attu:v2.3.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: attu
+          containerPort: 3000
+          protocol: TCP
+        env:
+        - name: MILVUS_URL
+          value: "my-release-milvus:19530"


### PR DESCRIPTION
Just had my first run at deploying Attu within my K8's Cluster. I thought I would update the readme and YAML configs to help others:

1. Added K8's instructions to readme
2. Changed environment variable to point at Milvus service instead
3. Added another YAML config deployment including to show good practise of config settings vs application code