### PR TITLE
support user defined HOST_URL

### DIFF
--- a/client/public/env-config.js
+++ b/client/public/env-config.js
@@ -1,6 +1,6 @@
 window._env_ = {
   MILVUS_URL: '127.0.0.1:19530',
-  HOST_URL: 'http://127.0.0.1:3000',
+  HOST_URL: '',
   IS_ELECTRON: '{{IS_ELECTRON}}',
   WITH_PROMETHEUS: '',
   PROMETHEUS_ADDRESS: '',

--- a/client/src/http/Axios.ts
+++ b/client/src/http/Axios.ts
@@ -1,14 +1,8 @@
 import axios from 'axios';
 import { MILVUS_ADDRESS } from '@/consts';
 
-// console.log(import.meta.env.NODE_ENV, 'api:', import.meta.env.VITE_BASE_URL);
-// console.log('docker env', (window as any)._env_);
-const isElectron =
-  (window as any)._env_ && (window as any)._env_.IS_ELECTRON === 'yes';
 export const url =
-  import.meta.env.MODE === 'development' || isElectron
-    ? (window as any)._env_ && (window as any)._env_.HOST_URL
-    : '';
+  ((window as any)._env_ && (window as any)._env_.HOST_URL) || '';
 
 const axiosInstance = axios.create({
   baseURL: `${url}/api/v1`,

--- a/client/src/http/Axios.ts
+++ b/client/src/http/Axios.ts
@@ -1,8 +1,19 @@
 import axios from 'axios';
 import { MILVUS_ADDRESS } from '@/consts';
 
-export const url =
-  ((window as any)._env_ && (window as any)._env_.HOST_URL) || '';
+// base hots url
+const DEFAULT_HOST_URL = `http://127.0.0.1:3000`;
+
+const hostUrl: { [key: string]: string | undefined } = {
+  development: DEFAULT_HOST_URL,
+  production: ((window as any)._env_ && (window as any)._env_.HOST_URL) || '',
+  electron: DEFAULT_HOST_URL,
+};
+
+const isElectron =
+  (window as any)._env_ && (window as any)._env_.IS_ELECTRON === 'yes';
+
+export const url = hostUrl[isElectron ? 'electron' : import.meta.env.MODE];
 
 const axiosInstance = axios.create({
   baseURL: `${url}/api/v1`,


### PR DESCRIPTION
We should support user to define HOST_URL from docker env settings, so user can put a proxy in front of attu service. 

related issue: #315

Don't know why we introduce this to handle the url, this shouldn't be related to electron at all. 
https://github.com/zilliztech/attu/commit/7f978226af7d2e5aec3234b52085f36bf74c8983
