### PR TITLE
hide index info on segments page

### DIFF
--- a/client/src/pages/segments/Segments.tsx
+++ b/client/src/pages/segments/Segments.tsx
@@ -134,12 +134,12 @@ const Segments: FC<{
       disablePadding: false,
       label: collectionTrans('q_state'),
     },
-    {
-      id: 'q_index_name',
-      align: 'left',
-      disablePadding: false,
-      label: collectionTrans('q_index_name'),
-    },
+    // {
+    //   id: 'q_index_name',
+    //   align: 'left',
+    //   disablePadding: false,
+    //   label: collectionTrans('q_index_name'),
+    // },
   ];
 
   useEffect(() => {


### PR DESCRIPTION
 since it is ambiguous here and we don't have enough api to get more precise info. 
 
  this resolve #350 