### PR TITLE
Feature: Ability to config server port via Environment Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ Make sure that the Attu container can access the Milvus IP address. After starti
 #### Optional Environment Variables for Running Attu Docker
 
 | Parameter        | Example              | Required | Description                             |
-| :--------------- | :------------------- | :------: | --------------------------------------- |
+|:-----------------|:---------------------| :------: |-----------------------------------------|
 | MILVUS_URL       | 192.168.0.1:19530    |  false   | Optional, Milvus server URL             |
 | ATTU_LOG_LEVEL   | info                 |  false   | Optional, sets the log level for Attu   |
 | ROOT_CERT_PATH   | /path/to/root/cert   |  false   | Optional, path to the root certificate  |
 | PRIVATE_KEY_PATH | /path/to/private/key |  false   | Optional, path to the private key       |
 | CERT_CHAIN_PATH  | /path/to/cert/chain  |  false   | Optional, path to the certificate chain |
 | SERVER_NAME      | your_server_name     |  false   | Optional, name of your server           |
+| SERVER_PORT      | Server listen port   |  false   | Optional, 3000 by default if unset      |
+
 
 > Please note that the `MILVUS_URL` should be an address that the Attu Docker container can access. Therefore, "127.0.0.1" or "localhost" will not work.
 
@@ -53,6 +55,19 @@ docker run -p 8000:3000 \
 -e PRIVATE_KEY_PATH=/app/tls/client.key \
 -e CERT_CHAIN_PATH=/app/tls/client.pem \
 -e SERVER_NAME=your_server_name \
+zilliz/attu:dev
+```
+
+#### Custom Server Port Example
+*This command lets you run the docker container with host networking, specificity a custom port for 
+the server to list on*
+
+```bash
+docker run --network host \
+-v /your-tls-file-path:/app/tls \
+-e ATTU_LOG_LEVEL=info  \
+-e SERVER_NAME=your_server_name \
+-e SERVER_PORT=8080 \
 zilliz/attu:dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ zilliz/attu:dev
 ```
 
 #### Custom Server Port Example
-*This command lets you run the docker container with host networking, specificity a custom port for 
-the server to list on*
+*This command lets you run the docker container with host networking, specifying a custom port for 
+the server to listen on*
 
 ```bash
 docker run --network host \

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -58,8 +58,6 @@ router.get('/healthy', (req, res, next) => {
 
 // initialize a simple http server
 const server = http.createServer(app);
-// default port 3000
-const PORT = 3000;
 
 // setup middlewares
 // use cors https://expressjs.com/en/resources/middleware/cors.html
@@ -92,6 +90,9 @@ app.get('*', (request, response) => {
 app.use(ErrorMiddleware);
 // init websocket server
 initWebSocket(server);
+
+// use port 3000 unless there exists a preconfigured port
+const PORT = process.env.SERVER_PORT || 3000;
 
 // start server
 server.listen(PORT, () => {


### PR DESCRIPTION
### Configure the Node.js Server Listen Port (optionally)

- Added the SERVER_PORT environment variable that will set the node.js listen port, if provided
- 3000 is still the default port if env var is not provided
- Updated readme to include new environment variable and show an example of using the custom port var with host networking

Server started successfully on local, with and without provided variable. `yarn test` was run though reported "No tests found".