### PR TITLE
support create multiple vectors in a collection

### DIFF
--- a/client/src/consts/Milvus.ts
+++ b/client/src/consts/Milvus.ts
@@ -19,8 +19,19 @@ export enum DataTypeEnum {
   JSON = 23,
   BinaryVector = 100,
   FloatVector = 101,
+  Float16Vector = 102,
+  SparseFloatVector = 104,
+  BFloat16Vector = 103,
   Array = 22,
 }
+
+export const vectorTypes = [
+  DataTypeEnum.BinaryVector,
+  DataTypeEnum.FloatVector,
+  DataTypeEnum.BFloat16Vector,
+  DataTypeEnum.Float16Vector,
+  DataTypeEnum.SparseFloatVector,
+];
 
 export enum INDEX_TYPES_ENUM {
   AUTOINDEX = 'AUTOINDEX',

--- a/client/src/pages/databases/collections/Constants.ts
+++ b/client/src/pages/databases/collections/Constants.ts
@@ -29,10 +29,22 @@ export const VECTOR_FIELDS_OPTIONS: LabelValuePair[] = [
     label: 'Float Vector',
     value: DataTypeEnum.FloatVector,
   },
+  {
+    label: 'Float16 Vector',
+    value: DataTypeEnum.Float16Vector,
+  },
+  {
+    label: 'BFloat16 Vector',
+    value: DataTypeEnum.BFloat16Vector,
+  },
+  {
+    label: 'Sparse Vector',
+    value: DataTypeEnum.SparseFloatVector,
+  },
 ];
 
 export const ALL_OPTIONS: LabelValuePair[] = [
-  // ...VECTOR_FIELDS_OPTIONS,
+  ...VECTOR_FIELDS_OPTIONS,
   {
     label: 'Int8',
     value: DataTypeEnum.Int8,

--- a/client/src/pages/dialogs/CreateCollectionDialog.tsx
+++ b/client/src/pages/dialogs/CreateCollectionDialog.tsx
@@ -13,7 +13,12 @@ import { ITextfieldConfig } from '@/components/customInput/Types';
 import { rootContext, dataContext } from '@/context';
 import { useFormValidation } from '@/hooks';
 import { formatForm, TypeEnum } from '@/utils';
-import { DataTypeEnum, ConsistencyLevelEnum, DEFAULT_ATTU_DIM } from '@/consts';
+import {
+  DataTypeEnum,
+  ConsistencyLevelEnum,
+  DEFAULT_ATTU_DIM,
+  vectorTypes,
+} from '@/consts';
 import CreateFields from '../databases/collections/CreateFields';
 import {
   CollectionCreateParam,
@@ -49,7 +54,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '100%',
   },
   select: {
-    width: '160px',
+    width: '170px',
 
     '&:first-child': {
       marginLeft: 0,
@@ -201,7 +206,6 @@ const CreateCollectionDialog: FC<CollectionCreateProps> = ({ onCreate }) => {
   ];
 
   const handleCreateCollection = async () => {
-    const vectorType = [DataTypeEnum.BinaryVector, DataTypeEnum.FloatVector];
     const param: CollectionCreateParam = {
       ...form,
       fields: fields.map(v => {
@@ -229,7 +233,7 @@ const CreateCollectionDialog: FC<CollectionCreateProps> = ({ onCreate }) => {
 
         v.is_primary_key && (data.autoID = form.autoID);
 
-        return vectorType.includes(v.data_type)
+        const param = vectorTypes.includes(v.data_type)
           ? {
               ...data,
               type_params: {
@@ -246,6 +250,13 @@ const CreateCollectionDialog: FC<CollectionCreateProps> = ({ onCreate }) => {
               },
             }
           : { ...data };
+
+        // delete sparse vector dime
+        if (param.data_type === DataTypeEnum.SparseFloatVector) {
+          delete param.type_params!.dim;
+        }
+
+        return param;
       }),
       consistency_level: consistencyLevel,
     };

--- a/client/src/utils/Format.ts
+++ b/client/src/utils/Format.ts
@@ -3,8 +3,12 @@ import {
   DEFAULT_MILVUS_PORT,
   DEFAULT_PROMETHEUS_PORT,
   DataTypeEnum,
+  vectorTypes,
 } from '@/consts';
-import { CreateFieldType, CreateField } from '@/pages/databases/collections/Types';
+import {
+  CreateFieldType,
+  CreateField,
+} from '@/pages/databases/collections/Types';
 import { FieldObject } from '@server/types';
 
 /**
@@ -104,7 +108,6 @@ export const getCreateFieldType = (config: CreateField): CreateFieldType => {
     return 'defaultVector';
   }
 
-  const vectorTypes = [DataTypeEnum.BinaryVector, DataTypeEnum.FloatVector];
   if (vectorTypes.includes(config.data_type)) {
     return 'vector';
   }


### PR DESCRIPTION
Milvus 2.4 support new vector types and creating multiple vector fields in a collection. this pr allows user to create multiple vectors in the create collection dialog

 #455 #453

![image](https://github.com/zilliztech/attu/assets/185051/ea0422ce-32ec-4b09-b0c7-74519704253a)
