### PR TITLE
fix: Translation mistake in dialog.ts

### DIFF
--- a/client/src/i18n/cn/dialog.ts
+++ b/client/src/i18n/cn/dialog.ts
@@ -1,5 +1,5 @@
 const dialogTrans = {
-  deleteTipAction: '类型',
+  deleteTipAction: '输入',
   deleteTipPurpose: '以确认。',
   deleteTitle: `删除 {{type}}`,
   renameTitle: `重命名 {{type}}`,


### PR DESCRIPTION
Fix translation mistake: Changed Chinese translation of "deleteTipAction" from "类型" to "输入"
![图片](https://github.com/zilliztech/attu/assets/30024226/15354be2-290b-4ca2-a8c1-1821af516496)