### PR TITLE
build mac-arm64/x64 application separately 

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -127,9 +127,13 @@
       "target": [
         {
           "target": "default",
-          "arch": "universal"
+          "arch": [
+            "arm64",
+            "x64"
+          ]
         }
-      ]
+      ],
+      "artifactName": "attu-${os}-${arch}-v${version}.${ext}"
     },
     "win": {
       "icon": "./build/attu.png",


### PR DESCRIPTION
this fix #532

```bash
 electron-builder --mac
  • electron-builder  version=24.13.3 os=23.2.0
  • loaded configuration  file=package.json ("build" field)
  • writing effective config  file=electron-app/builder-effective-config.yaml
  • packaging       platform=darwin arch=arm64 electron=30.0.8 appOutDir=electron-app/mac-arm64
  • skipped macOS application code signing  reason=cannot find valid "Developer ID Application" identity or custom non-Apple code signing certificate, it could cause some undefined behaviour, e.g. macOS localized description not visible, see https://electron.build/code-signing allIdentities=  1) 84E1C5DEAE382473B9A1CD39F4CA804597A970AE "79DA96C920D455EFBA7D6FD3812965D4" (CSSMERR_TP_CERT_EXPIRED)
     1 identities found
                                                Valid identities only
     0 valid identities found
  • building        target=macOS zip arch=arm64 file=electron-app/attu-mac-arm64-v2.4.1.zip
  • building        target=DMG arch=arm64 file=electron-app/attu-mac-arm64-v2.4.1.dmg
  • Detected arm64 process, HFS+ is unavailable. Creating dmg with APFS - supports Mac OSX 10.12+
  • packaging       platform=darwin arch=x64 electron=30.0.8 appOutDir=electron-app/mac
  • skipped macOS application code signing  reason=cannot find valid "Developer ID Application" identity or custom non-Apple code signing certificate, it could cause some undefined behaviour, e.g. macOS localized description not visible, see https://electron.build/code-signing allIdentities=  1) 84E1C5DEAE382473B9A1CD39F4CA804597A970AE "79DA96C920D455EFBA7D6FD3812965D4" (CSSMERR_TP_CERT_EXPIRED)
     1 identities found
                                                Valid identities only
     0 valid identities found
  • building        target=macOS zip arch=x64 file=electron-app/attu-mac-x64-v2.4.1.zip
  • building        target=DMG arch=x64 file=electron-app/attu-mac-x64-v2.4.1.dmg
  • Detected arm64 process, HFS+ is unavailable. Creating dmg with APFS - supports Mac OSX 10.12+
  • building block map  blockMapFile=electron-app/attu-mac-arm64-v2.4.1.dmg.blockmap
  • building block map  blockMapFile=electron-app/attu-mac-x64-v2.4.1.dmg.blockmap
  • building block map  blockMapFile=electron-app/attu-mac-arm64-v2.4.1.zip.blockmap
  • building block map  blockMapFile=electron-app/attu-mac-x64-v2.4.1.zip.blockmap
✨  Done in 45.24s.
```