### PR TITLE
added optional dbName in header for tls

### DIFF
--- a/server/src/milvus/milvus.service.ts
+++ b/server/src/milvus/milvus.service.ts
@@ -55,6 +55,10 @@ export class MilvusService {
         if (process.env.SERVER_NAME) {
           clientConfig.tls.serverName = process.env.SERVER_NAME;
         }
+
+        if (process.env.DB_NAME) {
+          clientConfig.database = process.env.DB_NAME;
+        }
       }
       // create the client
       const milvusClient: MilvusClient = new MilvusClient(clientConfig);

--- a/server/src/milvus/milvus.service.ts
+++ b/server/src/milvus/milvus.service.ts
@@ -37,6 +37,7 @@ export class MilvusService {
         username,
         password,
         logLevel: process.env.ATTU_LOG_LEVEL || 'info',
+        database: database || this.DEFAULT_DATABASE,
       };
 
       if (process.env.ROOT_CERT_PATH) {
@@ -54,10 +55,6 @@ export class MilvusService {
 
         if (process.env.SERVER_NAME) {
           clientConfig.tls.serverName = process.env.SERVER_NAME;
-        }
-
-        if (process.env.DB_NAME) {
-          clientConfig.database = process.env.DB_NAME;
         }
       }
       // create the client


### PR DESCRIPTION
In the case of a TLS-enabled environment, our Istio service needs a dbName in the header to route the request. In all our environments, we don't necessarily keep a "default" database, so we want to send something from the UI to it.

Without it, the Attu connection breaks on milvusClient.healthCheck(). 
With this code change it works fine.
