### PR TITLE
Fix: Typo in milvus-attu image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
 
   attu:
     container_name: milvus-attu
-    image: zilliz/attu:2.4.8
+    image: zilliz/attu:v2.4.8
     environment:
       MILVUS_URL: milvus:19530
     ports:


### PR DESCRIPTION
Image tag should be `v2.4.8` not `2.4.8`

Reference: https://hub.docker.com/r/zilliz/attu/tags?name=2.4.8
