### PR TITLE
Update use-attu-behind-proxy.md

### DIFF
--- a/doc/use-attu-behind-proxy.md
+++ b/doc/use-attu-behind-proxy.md
@@ -42,16 +42,6 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
-  location /socket.io/ {
-    proxy_pass http://localhost:3000/socket.io/;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "Upgrade";
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-  }
 }
 ```
 


### PR DESCRIPTION
Removed the Nginx configuration for rerouting /socket.io/ requests, as attu now correctly respects the HOST_URL environment variable. 

Ref : [https://github.com/zilliztech/attu/issues/893](https://github.com/zilliztech/attu/issues/893)